### PR TITLE
unix domain connection for hostname configured like "unix:/path_to_socke...

### DIFF
--- a/include/sphinxclient/sphinxclient.h
+++ b/include/sphinxclient/sphinxclient.h
@@ -218,6 +218,19 @@ public:
     int32_t getWriteTimeout() const;
     int32_t getConnectRetriesCount() const;
     int32_t getConnectRetryWait() const;
+
+    /**
+     * Check if unix domain socket have to be used.
+     * Searches "unix://..." in configured hostname.
+     * @return True if unix domain socket have to be used.
+     */
+    bool isDomainSocketUsed() const;
+
+    /**
+     * Return null terminated string containing unix domain socket path.
+     * Undefined behavior if called for isDomainSocketUsed() == false.
+     */
+    const char *getDomainSocketPath() const;
 };
 
 

--- a/src/querymachine.h
+++ b/src/querymachine.h
@@ -237,6 +237,11 @@ private:
         const Sphinx::ConnectionConfig_t &cconfig,
         struct addrinfo *&ai, struct addrinfo *&aip);
 
+    /// Connect using unix domain socket. Expected to call this just
+    /// if ConnectionConfig_t::isDomainSocketUsed() == true.
+    static int setupLocalConnection(
+        const Sphinx::ConnectionConfig_t &cconfig);
+
     /* @brief Internal state of query state machine
      */
     enum QueryState_t {

--- a/src/sphinxclient.cc
+++ b/src/sphinxclient.cc
@@ -196,6 +196,16 @@ int32_t Sphinx::ConnectionConfig_t::getConnectRetryWait() const
     return d->connectRetryWait;
 }
 
+bool Sphinx::ConnectionConfig_t::isDomainSocketUsed() const {
+    // check if first 6 bytes equals to "unix:/"
+    return d->host.compare(0, 6, "unix:/") == 0;
+}
+
+const char *Sphinx::ConnectionConfig_t::getDomainSocketPath() const {
+    // skip "unix:/" part from host and return the rest of host string.
+    return d->host.c_str() + 6;
+}
+
 //------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Local connection to sphinx does not need to waste system network resources - added possibility to configure sphinx connection over unix domain socket.
Configuration made like it is in nginx - "unix:/**path**" as a hostname, where **path** is path to sphinx unix domain socket.
